### PR TITLE
Missing '--help' to generators options

### DIFF
--- a/rails.bash
+++ b/rails.bash
@@ -73,6 +73,7 @@ __rails_generators_create_cache(){
         boolean_opt = opt.type == :boolean || opt.banner.empty?
         boolean_opt ? opt.switch_name : \"#{opt.switch_name}=\"
       end
+      options << '--help'
       hash[generator.namespace.gsub(/^rails:/, '')] = options
       hash
     end


### PR DESCRIPTION
Hello,

I often use `rails g scaffold --help`, for example.

Seen that every generator has `--help` option, I pushed it in the `options` array of every generator... of course, feel free to implement it as you wish :)

Cheers
