### PR TITLE
Documentation fixes: add bash v4 as requirement and and instructions to install it

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,15 @@ Current version of `bash_completion` supports all command-line options available
 
     https://github.com/jweslley/rails_completion/tree/v0.1.9
 
+### Brew install of Bash 4 (Mac OSX)
+Mac OSX still uses the old version 3.2 of bash, which is not compatible to `rails_completion`.
+Install the current version 4 of bash like this:
+```bash
+brew install bash
+sudo bash -c "echo '/usr/local/bin/bash' >> /etc/shells"
+chsh -s /usr/local/bin/bash
+```
+
 ## Installation
 
 ### Brew install (OSX)

--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,16 @@ The completion routines provide support for completing:
 * rails field's types on generators (e.g.: scaffold, model, migration, ...)
 * common --long-options
 
+## Requirements
+
+  * Rails 3
+  * Bash 4
+  * bash_completion 1.1+.
+
+Current version of `bash_completion` supports all command-line options available in Rails 3.2.x, if you want to use it with Rails 3.0.y or 3.1.z you should check this version:
+
+    https://github.com/jweslley/rails_completion/tree/v0.1.9
+
 ## Installation
 
 ### Brew install (OSX)
@@ -34,16 +44,6 @@ fi
         source ~/.rails.bash
 
 Alternatively, on Debian systems, you can just copy the `rails.bash` file to `/etc/bash_completion.d/` directory.
-
-## Requirements
-
-  * Rails 3
-  * Bash 4
-  * bash_completion 1.1+.
-
-Current version of `bash_completion` supports all command-line options available in Rails 3.2.x, if you want to use it with Rails 3.0.y or 3.1.z you should check this version:
-
-    https://github.com/jweslley/rails_completion/tree/v0.1.9
 
 ## Basic Usage
 

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,6 @@ The completion routines provide support for completing:
 ## Installation
 
 ### Brew install (OSX)
-
 ```bash
 brew tap homebrew/completions
 brew install rails-completion
@@ -39,6 +38,7 @@ Alternatively, on Debian systems, you can just copy the `rails.bash` file to `/e
 ## Requirements
 
   * Rails 3
+  * Bash 4
   * bash_completion 1.1+.
 
 Current version of `bash_completion` supports all command-line options available in Rails 3.2.x, if you want to use it with Rails 3.0.y or 3.1.z you should check this version:


### PR DESCRIPTION
Some small documentation fixes:
- move the requirement-section above the installation section
- update the requirement-section and add bash 4 as requirement
- add instruction how to install bash 4 on mac osx using homebrew

this should fix issue #13
